### PR TITLE
Fix project documentation internal links.

### DIFF
--- a/documentation/client.md
+++ b/documentation/client.md
@@ -1,12 +1,12 @@
 
 ## Using the Client
 
-- [Purpose of the Client](client.md#Purpose of the Client)
-- [Getting Started](client.md#Getting Started)
-- [Authentication](client.md#Authentication)
-- [Creating a Resource](client.md#Creating a Resource)
-- [Finding Resources](client.md#Finding Resources)
-- [Getting a Resource](client.md#Getting a Resource)
+- [Purpose of the Client](#purpose-of-the-client)
+- [Getting Started](#getting-started)
+- [Authentication](#authentication)
+- [Creating a Resource](#creating-a-resource)
+- [Finding Resources](#finding-resources)
+- [Getting a Resource](#getting-a-resource)
 
 #### Purpose of the Client
 

--- a/documentation/error.md
+++ b/documentation/error.md
@@ -1,8 +1,8 @@
 
 ## Errors
 
-- [Purpose of Errors](client.md#Purpose of Errors)
-- [Error properties](client.md#Error properties)
+- [Purpose of Errors](#purpose-of-errors)
+- [Error properties](#error-properties)
 
 #### Purpose of Errors
 

--- a/documentation/resource.md
+++ b/documentation/resource.md
@@ -3,15 +3,14 @@
 
 Foreword: All resource objects are [interned](resource-interning.md).
 
-- [Examining resource attributes](client.md#Examining resource attributes)
-- [Setting resource attributes](client.md#Setting resource attributes)
-- [Syncing a resource with the remote service](client.md#Syncing a resource with the remote service)
-- [Flattening a resource](client.md#Flattening a resource)
-- [Debugging nested resources](client.md#Debugging nested resources)
-- [Flattening a resource](client.md#Flattening a resource)
-- [Debugging nested resources](client.md#Debugging nested resources)
-- [Changing resource relations](client.md#Changing resource relations)
-- [Deleting a resource](client.md#Deleting a resource)
+- [Examining resource attributes](#examining-resource-attributes)
+- [Setting resource attributes](#setting-resource-attributes)
+- [Syncing a resource with the remote service](#syncing-a-resource-with-the-remote-service)
+- [Flattening a resource](#flattening-a-resource)
+- [Debugging nested resources](#debugging-nested-resources)
+- [Fetching related resources](#fetching-related-resources)
+- [Changing resource relations](#changing-resource-relations)
+- [Deleting a resource](#deleting-a-resource)
 
 #### Examining resource attributes
 


### PR DESCRIPTION
The internal links to sections in the documentation were suffering from copy-paste syndrome and didn't use the right format. This PR fixes them.
