### PR TITLE
Fix code climate rating

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,4 @@
+languages:
+  JavaScript: true
+exclude_paths:
+- "dist/*.js"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Coverage Status](https://coveralls.io/repos/holidayextras/jsonapi-client/badge.svg?branch=master&service=github)](https://coveralls.io/github/holidayextras/jsonapi-client?branch=master)
 [![Build Status](https://travis-ci.org/holidayextras/jsonapi-client.svg?branch=master)](https://travis-ci.org/holidayextras/jsonapi-client)
 [![Code Climate](https://codeclimate.com/github/holidayextras/jsonapi-client/badges/gpa.svg)](https://codeclimate.com/github/holidayextras/jsonapi-client)
+[![Codacy Badge](https://api.codacy.com/project/badge/grade/3998acb1f4c6433a93a688e9523e37e0)](https://www.codacy.com/app/oliver-rumbelow-github/jsonapi-client)
 [![Dependencies Status](https://david-dm.org/holidayextras/jsonapi-client.svg)](https://david-dm.org/holidayextras/jsonapi-client)
 
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/theninj4.svg)](https://saucelabs.com/u/theninj4)


### PR DESCRIPTION
CodeClimate is including the browserified test bundle in its ratings, which is wildly degrading the score. This PR adds a `.codeclimate.yml` file to tell codeclimate to ignore the `/dist` folder.
