### PR TITLE
Better error handling of non-conformant json:api responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 2015-12-17 - v0.1.0 Adding authentication
 2015-12-17 - v0.2.0 Better validation when changing relations
 2015-12-17 - v0.3.0 Fixes to enable usage in web browsers
+2015-12-17 - v0.4.0 Better handling of non-json:api payloads

--- a/dist/jsonapi-client-test.js
+++ b/dist/jsonapi-client-test.js
@@ -447,7 +447,7 @@ Transport.prototype._action = function(method, url, data, callback) {
         return callback(Transport._defaultError(response));
       }
 
-      if (!(response.errors instanceof Array)) {
+      if (!Array.isArray(response.errors)) {
         console.error("Invalid Error payload!", response);
         return callback(Transport._defaultError(response));
       }
@@ -16887,7 +16887,7 @@ describe("Testing jsonapi-client", function() {
   });
 
   describe("testing invalid payloads", function() {
-    it("doesnt crash when we get a non-conformant response", function(done) {
+    it("doesn't crash when we get a non-conformant response", function(done) {
       var badClient = new Client("http://localhost:12345");
       badClient.find("articles", { }, function(err) {
         assert.deepEqual(err, {

--- a/dist/jsonapi-client-test.js
+++ b/dist/jsonapi-client-test.js
@@ -465,7 +465,11 @@ Transport.prototype._action = function(method, url, data, callback) {
     }
 
     if (!payload.body) {
-      payload.body = JSON.parse(payload.text);
+      try {
+        payload.body = JSON.parse(payload.text);
+      } catch(e) {
+        return callback(Transport._defaultError(payload));
+      }
     }
 
     if (!payload.body) {

--- a/dist/jsonapi-client-test.js
+++ b/dist/jsonapi-client-test.js
@@ -413,6 +413,15 @@ Transport.prototype._attachAuthToRequest = function(someRequest) {
   }
 };
 
+Transport._defaultError = function(response) {
+  return {
+    status: "500",
+    code: "EUNKNOWN",
+    title: "An unknown error has occured",
+    detail: response
+  };
+};
+
 Transport.prototype._action = function(method, url, data, callback) {
   // console.log(method, url, JSON.stringify(data, null, 2));
   var someRequest = request[method](url);
@@ -435,7 +444,12 @@ Transport.prototype._action = function(method, url, data, callback) {
         response = JSON.parse(err.response.text);
       } catch(e) {
         console.error("Transport Error: " + JSON.stringify(err));
-        return callback(new Error("Invalid response from server"));
+        return callback(Transport._defaultError(response));
+      }
+
+      if (!(response.errors instanceof Array)) {
+        console.error("Invalid Error payload!", response);
+        return callback(Transport._defaultError(response));
       }
 
       var realErrors = response.errors.map(function(apiError) {
@@ -452,6 +466,10 @@ Transport.prototype._action = function(method, url, data, callback) {
 
     if (!payload.body) {
       payload.body = JSON.parse(payload.text);
+    }
+
+    if (!payload.body) {
+      return callback(Transport._defaultError(payload));
     }
 
     return callback(null, payload.body, payload.body.data, payload.body.included);
@@ -16866,6 +16884,21 @@ describe("Testing jsonapi-client", function() {
       assert.throws(function() { person.relationships("photos"); });
     });
 
+  });
+
+  describe("testing invalid payloads", function() {
+    it("doesnt crash when we get a non-conformant response", function(done) {
+      var badClient = new Client("http://localhost:12345");
+      badClient.find("articles", { }, function(err) {
+        assert.deepEqual(err, {
+          "status": "500",
+          "code": "EUNKNOWN",
+          "title": "An unknown error has occured",
+          "detail": undefined
+        });
+        done();
+      });
+    });
   });
 
 });

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -27,6 +27,15 @@ Transport.prototype._attachAuthToRequest = function(someRequest) {
   }
 };
 
+Transport._defaultError = function(response) {
+  return {
+    status: "500",
+    code: "EUNKNOWN",
+    title: "An unknown error has occured",
+    detail: response
+  };
+};
+
 Transport.prototype._action = function(method, url, data, callback) {
   // console.log(method, url, JSON.stringify(data, null, 2));
   var someRequest = request[method](url);
@@ -49,7 +58,12 @@ Transport.prototype._action = function(method, url, data, callback) {
         response = JSON.parse(err.response.text);
       } catch(e) {
         console.error("Transport Error: " + JSON.stringify(err));
-        return callback(new Error("Invalid response from server"));
+        return callback(Transport._defaultError(response));
+      }
+
+      if (!(response.errors instanceof Array)) {
+        console.error("Invalid Error payload!", response);
+        return callback(Transport._defaultError(response));
       }
 
       var realErrors = response.errors.map(function(apiError) {
@@ -66,6 +80,10 @@ Transport.prototype._action = function(method, url, data, callback) {
 
     if (!payload.body) {
       payload.body = JSON.parse(payload.text);
+    }
+
+    if (!payload.body) {
+      return callback(Transport._defaultError(payload));
     }
 
     return callback(null, payload.body, payload.body.data, payload.body.included);

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -79,7 +79,11 @@ Transport.prototype._action = function(method, url, data, callback) {
     }
 
     if (!payload.body) {
-      payload.body = JSON.parse(payload.text);
+      try {
+        payload.body = JSON.parse(payload.text);
+      } catch(e) {
+        return callback(Transport._defaultError(payload));
+      }
     }
 
     if (!payload.body) {

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -61,7 +61,7 @@ Transport.prototype._action = function(method, url, data, callback) {
         return callback(Transport._defaultError(response));
       }
 
-      if (!(response.errors instanceof Array)) {
+      if (!Array.isArray(response.errors)) {
         console.error("Invalid Error payload!", response);
         return callback(Transport._defaultError(response));
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A clientside module designed to make it really easy to consume a json:api service.",
   "keywords": [
     "jsonapi",

--- a/test/read.js
+++ b/test/read.js
@@ -256,7 +256,7 @@ describe("Testing jsonapi-client", function() {
   });
 
   describe("testing invalid payloads", function() {
-    it("doesnt crash when we get a non-conformant response", function(done) {
+    it("doesn't crash when we get a non-conformant response", function(done) {
       var badClient = new Client("http://localhost:12345");
       badClient.find("articles", { }, function(err) {
         assert.deepEqual(err, {

--- a/test/read.js
+++ b/test/read.js
@@ -255,4 +255,19 @@ describe("Testing jsonapi-client", function() {
 
   });
 
+  describe("testing invalid payloads", function() {
+    it("doesnt crash when we get a non-conformant response", function(done) {
+      var badClient = new Client("http://localhost:12345");
+      badClient.find("articles", { }, function(err) {
+        assert.deepEqual(err, {
+          "status": "500",
+          "code": "EUNKNOWN",
+          "title": "An unknown error has occured",
+          "detail": undefined
+        });
+        done();
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
If we get a non-conformant response to a request, we should be producing a generic json:api compliant error to pass back up the stack. Right now, we're either passing back objects that don't meet the consumers expectations, or throwing exceptions as we try and access properties that don't exist.
