### PR TITLE
ensure not to iterate over missing rawIncludes

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -35,9 +35,11 @@ Client.prototype.find = Promise.denodeify(function(type, options, callback) {
     var resources = rawResources.map(function(someRawResource) {
       return new Resource(someRawResource, self);
     });
-    rawIncludes.forEach(function(someRawResource) {
-      return new Resource(someRawResource, self);
-    });
+    if (rawIncludes) {
+      rawIncludes.forEach(function(someRawResource) {
+        return new Resource(someRawResource, self);
+      });
+    }
 
     return callback(null, resources);
   });
@@ -55,9 +57,11 @@ Client.prototype.get = Promise.denodeify(function(type, id, options, callback) {
     if (err) return callback(err);
 
     var resource = new Resource(rawResource, self);
-    rawIncludes.forEach(function(someRawResource) {
-      return new Resource(someRawResource, self);
-    });
+    if (rawIncludes) {
+      rawIncludes.forEach(function(someRawResource) {
+        return new Resource(someRawResource, self);
+      });
+    }
 
     return callback(null, resource);
   });


### PR DESCRIPTION
When the optional top level member `included` is missing the code breaks. This PR fixes this issue.
