### PR TITLE
fix meta handling by providing defaults if they not exist

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -9,6 +9,11 @@ var Promise = require("promise");
 var _ = require("lodash");
 var resourceCache = require("./resourceCache.js");
 
+function getMeta(obj) {
+  var metaDefaults = { relation: "primary" };
+  return obj.meta || metaDefaults;
+}
+
 Resource.prototype._construct = function(rawResource, client) {
   this._raw = rawResource;
   this._base = {
@@ -48,7 +53,7 @@ Resource.prototype._getDelta = function() {
   var primaryRelations = { };
   var relationships = this._getRaw().relationships;
   Object.keys(relationships).forEach(function(i) {
-    if (relationships[i].meta.relation === "foreign") return;
+    if (getMeta(relationships[i]).relation === "foreign") return;
     primaryRelations[i] = relationships[i];
   });
 
@@ -88,7 +93,7 @@ Resource.prototype._relationHasResource = function(relationName, resource) {
 };
 
 Resource._rawRelationHasMany = function(rawRelation) {
-  var meta = rawRelation.meta;
+  var meta = getMeta(rawRelation);
   if (meta.relation === "primary") return (rawRelation.data instanceof Array);
   return meta.many;
 };
@@ -101,12 +106,13 @@ Resource.prototype._associateWith = function(resource) {
     var rawRelation = relationships[relationName];
     var otherRelation = resource;
     var rawRelationData = rawRelation.data;
-    if (rawRelation.meta.relation === "foreign") {
-      if (rawRelation.meta.belongsTo !== resource._getBase().type) {
+    var rawRelationMeta = getMeta(rawRelation);
+    if (rawRelationMeta.relation === "foreign") {
+      if (rawRelationMeta.belongsTo !== resource._getBase().type) {
         return;
       }
       otherRelation = self;
-      rawRelationData = resource._getRaw().relationships[rawRelation.meta.as].data;
+      rawRelationData = resource._getRaw().relationships[rawRelationMeta.as].data;
     }
 
     var match = !![].concat(rawRelationData).filter(function(dataItem) {
@@ -133,7 +139,7 @@ Resource.prototype.relationships = function(relationName) {
     throw new Error("Relationship " + relationName + " on " + this._raw.type + " does not exist!");
   }
 
-  if (rawRelation.meta.relation === "foreign") {
+  if (getMeta(rawRelation).relation === "foreign") {
     throw new Error("Relationship " + relationName + " on " + this._raw.type + " is a foreign relation and cannot be updated from here!");
   }
 
@@ -269,10 +275,11 @@ Resource.prototype._tweakLinksTo = function(method, resource) {
   if (!self._raw.relationships) return;
   Object.keys(self._raw.relationships).forEach(function(i) {
     var someRawRelationship = self._raw.relationships[i];
-    if (someRawRelationship.meta.relation !== "foreign") return;
-    if (someRawRelationship.meta.belongsTo !== resource._raw.type) return;
+    var someRawRelationshipMeta = getMeta(someRawRelationship);
+    if (someRawRelationshipMeta.relation !== "foreign") return;
+    if (someRawRelationshipMeta.belongsTo !== resource._raw.type) return;
 
-    self["_" + method + "LinksTo"](i, resource, someRawRelationship.meta.many);
+    self["_" + method + "LinksTo"](i, resource, someRawRelationshipMeta.many);
   });
 };
 


### PR DESCRIPTION
When optional `meta` information is missing code breaks. This PR fixes this issue.
