### PR TITLE
provide one resourceCache per client

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -16,8 +16,10 @@ var Promise = require("promise");
 var Resource = require("./Resource");
 Client.Resource = Resource;
 var Transport = require("./Transport");
+var createResourceCache = require("./resourceCache");
 
 Client.prototype._construct = function(path, auth) {
+  this._resourceCache = createResourceCache();
   this._transport = new Transport(path, auth);
 };
 

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -7,7 +7,6 @@ var Resource = module.exports = function(rawResource, client) {
 var Promise = require("promise");
 // Promise.denodeify = function(a) { return a; };
 var _ = require("lodash");
-var resourceCache = require("./resourceCache.js");
 
 Resource.prototype._construct = function(rawResource, client) {
   this._raw = rawResource;
@@ -20,10 +19,10 @@ Resource.prototype._construct = function(rawResource, client) {
 
   if (!this._base.id) return this;
 
-  var fromCache = resourceCache.get(this);
+  var fromCache = client._resourceCache.get(this);
   if (fromCache) return fromCache;
 
-  resourceCache.set(this);
+  client._resourceCache.set(this);
   return this;
 };
 
@@ -256,7 +255,7 @@ Resource.prototype.delete = Promise.denodeify(function(callback) {
   self._client._delete(self, function(err) {
     if (err) return callback(err);
 
-    resourceCache.removeFromCache(self);
+    self._client._resourceCache.removeFromCache(self);
     self._getBase().id = null;
     self._getRaw().id = null;
 

--- a/lib/resourceCache.js
+++ b/lib/resourceCache.js
@@ -1,35 +1,39 @@
 "use strict";
-var resourceCache = module.exports = { };
+module.exports = function createResourceCache() {
+  var resourceCache = {};
 
-resourceCache._cacheDuration = 5000;
-if (typeof module === undefined) {
-  resourceCache._cacheDuration = null;
-}
-resourceCache._cache = { };
-resourceCache._cacheList = [ ];
+  resourceCache._cacheDuration = 5000;
+  if (typeof module === undefined) {
+    resourceCache._cacheDuration = null;
+  }
+  resourceCache._cache = { };
+  resourceCache._cacheList = [ ];
 
-resourceCache.get = function(someResource) {
-  var key = someResource._getUidString();
-  return resourceCache._cache[key];
-};
+  resourceCache.get = function(someResource) {
+    var key = someResource._getUidString();
+    return resourceCache._cache[key];
+  };
 
-resourceCache.set = function(someResource) {
-  someResource._associateWithAll(resourceCache._cacheList);
+  resourceCache.set = function(someResource) {
+    someResource._associateWithAll(resourceCache._cacheList);
 
-  var key = someResource._getUidString();
-  resourceCache._cache[key] = someResource;
-  resourceCache._cacheList.push(someResource);
+    var key = someResource._getUidString();
+    resourceCache._cache[key] = someResource;
+    resourceCache._cacheList.push(someResource);
 
-  if (!resourceCache._cacheDuration) return;
+    if (!resourceCache._cacheDuration) return;
 
-  setTimeout(function() {
-    resourceCache.removeFromCache(someResource);
-  }, resourceCache._cacheDuration);
-};
+    setTimeout(function() {
+      resourceCache.removeFromCache(someResource);
+    }, resourceCache._cacheDuration);
+  };
 
-resourceCache.removeFromCache = function(someResource) {
-  var key = someResource._getUidString();
-  resourceCache._cache[key] = undefined;
-  var i = resourceCache._cacheList.indexOf(someResource);
-  resourceCache._cacheList.splice(i, 1);
+  resourceCache.removeFromCache = function(someResource) {
+    var key = someResource._getUidString();
+    resourceCache._cache[key] = undefined;
+    var i = resourceCache._cacheList.indexOf(someResource);
+    resourceCache._cacheList.splice(i, 1);
+  };
+
+  return resourceCache;
 };


### PR DESCRIPTION
When using multiple `Client` instances, the global `resourceCache` may cause some trouble like e.g. included resources are missing. This PR fixes this issue by giving every `Client` instance it's own `resourceCache`.
