### PR TITLE
replace lodash with vanilla JS and ES2015 Object.assign ponyfill

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -6,7 +6,7 @@ var Resource = module.exports = function(rawResource, client) {
 
 var Promise = require("promise");
 // Promise.denodeify = function(a) { return a; };
-var _ = require("lodash");
+var assign = require("object-assign");
 var resourceCache = require("./resourceCache.js");
 
 Resource.prototype._construct = function(rawResource, client) {
@@ -83,8 +83,8 @@ Resource.prototype._associateWithAll = function(resources) {
 };
 
 Resource.prototype._relationHasResource = function(relationName, resource) {
-  if (!this[relationName]) return false;
-  return _.some(this[relationName], { _base: resource._base });
+  var relation = this[relationName];
+  return !!relation && (relation._base === resource._base);
 };
 
 Resource._rawRelationHasMany = function(rawRelation) {
@@ -185,7 +185,7 @@ Resource.prototype._setRelation = function(relationName, rawRelation, resource) 
 
 Resource.prototype.toJSON = function() {
   var theirs = this._raw;
-  var theirResource = _.assign({
+  var theirResource = assign({
     id: theirs.id,
     type: theirs.type
   }, theirs.attributes);
@@ -200,7 +200,7 @@ Resource.prototype.toJSONTree = function(seen) {
   if (seen.indexOf(this) !== -1) return "[Circular]";
   seen.push(this);
   var theirs = this._raw;
-  var theirResource = _.assign({
+  var theirResource = assign({
     id: theirs.id,
     type: theirs.type
   }, theirs.attributes);

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "config": {
     "blanket": {
-      "pattern": "/jsonapi-client/lib/",
+      "pattern": "/jsonapi-client\/lib/",
       "data-cover-never": [
         "node_modules",
         "test",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "async": "1.5.2",
-    "lodash": "3.10.1",
+    "object-assign": "4.0.1",
     "perry": "0.1.3",
     "promise": "7.1.1",
     "superagent": "1.7.1"
@@ -59,7 +59,7 @@
   },
   "config": {
     "blanket": {
-      "pattern": "/jsonapi-client\/lib/",
+      "pattern": "/jsonapi-client/lib/",
       "data-cover-never": [
         "node_modules",
         "test",


### PR DESCRIPTION
This PR replaces `lodash` with some vanilla JS and a ES2015 Object.assign ponyfill to save some bytes especially for browser clients.
