### PR TITLE
Set correct content-type header for requests to server

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -44,7 +44,7 @@ Transport.prototype._action = function(method, url, data, callback) {
   if (method === "get") {
     someRequest = someRequest.query(Perry.stringify(data));
   } else {
-    someRequest = someRequest.send(data);
+    someRequest = someRequest.send(data || {});
   }
   someRequest.end(function(err, payload) {
     // console.log("=>", err, payload);

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -39,6 +39,7 @@ Transport._defaultError = function(response) {
 Transport.prototype._action = function(method, url, data, callback) {
   // console.log(method, url, JSON.stringify(data, null, 2));
   var someRequest = request[method](url);
+  someRequest.set("Content-Type", "application/vnd.api+json");
   this._attachAuthToRequest(someRequest);
   if (method === "get") {
     someRequest = someRequest.query(Perry.stringify(data));


### PR DESCRIPTION
According to http://jsonapi.org/format/#content-negotiation the client must set the `Content-Type` header to `application/vnd.api+json`.
