### PR TITLE
Check for Related Resources before mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+ - 2016-03-10 - v0.4.3 Error handling when fetching related resources that don't exist
  - 2016-02-10 - v0.4.2 Fix adding/removing resources to/from relationships
  - 2016-02-08 - v0.4.1 Handling resources with no relationships
  - 2015-12-17 - v0.4.0 Better handling of non-json:api payloads

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -230,6 +230,7 @@ Resource.prototype.set = function(attributeName, value) {
 Resource.prototype.fetch = Promise.denodeify(function(relationName, callback) {
   var self = this;
   self._client._getRelated(this, relationName, function(err, newResources) {
+    if (!newResources) return callback("No related resources found");
     self._raw.relationships[relationName].data = newResources.map(function(someResource) {
       return someResource._getBase();
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi-client",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A clientside module designed to make it really easy to consume a json:api service.",
   "keywords": [
     "jsonapi",


### PR DESCRIPTION
This adds some error handling in the event that a resource has no related resources. This prevents an uncaught exception when we try to call map on undefined
- [x] This makes sense
- [x] I agree
