### PR TITLE
Safer Error Extraction

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -66,6 +66,10 @@ Transport.prototype._action = function(method, url, data, callback) {
         return callback(Transport._defaultError(response));
       }
 
+      if (!(response.errors instanceof Array)) {
+        return callback(Transport._defaultError(response));
+      }
+
       var realErrors = response.errors.map(function(apiError) {
         var someError = new Error(JSON.stringify(apiError.detail));
         someError.name = apiError.title;


### PR DESCRIPTION
In master, we don't check an error response is valid before trying to extract error messages from it. This can cause unexpected errors to be thrown if a backend service doesn't behave as expected.

Fixes #13 
