### PR TITLE
Correctly deduplicate related resources

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -88,7 +88,14 @@ Resource.prototype._associateWithAll = function(resources) {
 
 Resource.prototype._relationHasResource = function(relationName, resource) {
   var relation = this[relationName];
-  return !!relation && (relation._base === resource._base);
+
+  if (relation instanceof Array) {
+    relation = relation.filter(function(i) {
+      return (i._base === resource._base);
+    }).pop();
+  }
+
+  return !!relation;
 };
 
 Resource._rawRelationHasMany = function(rawRelation) {


### PR DESCRIPTION
The `_relationHasResource` is invoked on a resource when we want to add another resource to a relation. It needs to say "return true if this resources list of related resources already includes this new resource", thus de-duplicating related resources.

If we make a new resource `A` and add a related resource of `B` it'll look something like this:

```
A => [ B ]
```

If we then try and add `B` again, we need to de-duplicate it as-per the JSON:API spec.
