### PR TITLE
Allow relations on new resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,14 @@ article.delete(function(err) {
   console.log("Resource deleted");
 });
 ```
+
+#### A more complex example
+```javascript
+}).then(function() {
+  return client.create("articles")
+    .set("title", "some fancy booklet")
+    .set("content", "oh-la-la!")
+    .relationships("tags").add(someTagResource)
+    .sync();
+}).then(function(newlyCreatedArticle) {
+```

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -32,7 +32,11 @@ Resource.prototype._construct = function(rawResource, client) {
 };
 
 Resource.prototype._checkIsResource = function(resource) {
-  if (resource instanceof Resource) return;
+  if (resource instanceof Resource) {
+    if (!resource._base.id) throw new Error("Resource has not been created remotely, it can't be assigned to a relationship!");
+    return;
+  }
+
 
   var type = typeof resource;
   if (resource.constructor) type = resource.constructor.name;
@@ -141,6 +145,14 @@ Resource.prototype.relationships = function(relationName) {
   var self = this;
   var rawRelation = this._raw.relationships[relationName];
 
+  if (!self._base.id) {
+    rawRelation = this._raw.relationships[relationName] = {
+      meta: { _trust: true },
+      links: { },
+      data: null
+    };
+  }
+
   if (!rawRelation) {
     throw new Error("Relationship " + relationName + " on " + this._raw.type + " does not exist!");
   }
@@ -151,29 +163,38 @@ Resource.prototype.relationships = function(relationName) {
 
   return {
     add: function(resource) {
-      self._addRelation(relationName, rawRelation, resource);
+      return self._addRelation(relationName, rawRelation, resource);
     },
     set: function(resource) {
-      self._setRelation(relationName, rawRelation, resource);
+      return self._setRelation(relationName, rawRelation, resource);
     },
     remove: function(resource) {
-      self._removeRelation(relationName, rawRelation, resource);
+      return self._removeRelation(relationName, rawRelation, resource);
     }
   };
 };
 Resource.prototype._addRelation = function(relationName, rawRelation, resource) {
   this._checkIsResource(resource);
+  if (rawRelation.meta && rawRelation.meta._trust) {
+    delete rawRelation.meta;
+    rawRelation.data = [ ];
+  }
   if (!Resource._rawRelationHasMany(rawRelation)) {
     throw new Error("Relationship " + relationName + " on " + this._raw.type + " is a not a MANY relationship and cannot be added to!");
   }
-  if (this._relationHasResource(relationName, resource)) return;
+  if (this._relationHasResource(relationName, resource)) return this;
   rawRelation.data.push(resource._getBase());
   this[relationName] = this[relationName] || [];
   this[relationName].push(resource);
   resource._tweakLinksTo("add", this);
+  return this;
 };
 Resource.prototype._removeRelation = function(relationName, rawRelation, resource) {
   this._checkIsResource(resource);
+  if (rawRelation.meta && rawRelation.meta._trust) {
+    delete rawRelation.meta;
+    rawRelation.data = [ ];
+  }
   if (Resource._rawRelationHasMany(rawRelation)) {
     rawRelation.data = rawRelation.data.filter(function(id) {
       return !resource._matches(id);
@@ -187,12 +208,14 @@ Resource.prototype._removeRelation = function(relationName, rawRelation, resourc
     this[relationName] = undefined;
   }
   resource._tweakLinksTo("remove", this);
+  return this;
 };
 Resource.prototype._setRelation = function(relationName, rawRelation, resource) {
   this._checkIsResource(resource);
   rawRelation.data = resource._getBase();
   this[relationName] = resource;
   resource._tweakLinksTo("add", this);
+  return this;
 };
 
 Resource.prototype.toJSON = function() {
@@ -237,6 +260,7 @@ Resource.prototype.get = function(attibuteName) {
 Resource.prototype.set = function(attributeName, value) {
   this._raw.attributes[attributeName] = value;
   this._changed.push(attributeName);
+  return this;
 };
 
 Resource.prototype.fetch = Promise.denodeify(function(relationName, callback) {
@@ -260,7 +284,7 @@ Resource.prototype.sync = Promise.denodeify(function(callback) {
   target.call(self._client, self, function(err, rawResponse, rawResource) {
     if (err) return callback(err);
     self._construct(rawResource, self._client);
-    return callback();
+    return callback(null, self);
   });
 });
 

--- a/test/write.js
+++ b/test/write.js
@@ -202,6 +202,22 @@ describe("Testing jsonapi-client", function() {
         setTimeout(function() { throw err; }, 0);
       });
     });
+
+    it("doesn't allow us to assign non-existing resources", function(done) {
+      var someTag, newTag;
+
+      client.find("tags", { }).then(function(allTags) {
+        someTag = allTags[0];
+
+        newTag = client.create("tags")
+          .set("name", "not-ready-yet");
+
+        assert.throws(function() {
+          someTag.relationships("parent").set(newTag);
+        });
+        done();
+      });
+    });
   });
 
 });

--- a/test/write.js
+++ b/test/write.js
@@ -197,6 +197,8 @@ describe("Testing jsonapi-client", function() {
         return someTag.fetch("articles");
       }).then(function() {
         assert.equal(someTag.articles[0], newArticle);
+        return newArticle.delete();
+      }).then(function() {
         done();
       }).catch(function(err) {
         setTimeout(function() { throw err; }, 0);

--- a/test/write.js
+++ b/test/write.js
@@ -114,7 +114,7 @@ describe("Testing jsonapi-client", function() {
           res.article.relationships("tags").add(res.tag);
           async.waterfall([
             function(cb) {
-              res.article.sync(cb);
+              res.article.sync(function() { cb(); });
             },
             function(cb) {
               res.article.fetch("tags", cb);
@@ -132,7 +132,7 @@ describe("Testing jsonapi-client", function() {
           res.article.relationships("tags").remove(res.tag);
           async.waterfall([
             function(cb) {
-              res.article.sync(cb);
+              res.article.sync(function() { cb(); });
             },
             function(cb) {
               res.article.fetch("tags", cb);
@@ -178,6 +178,28 @@ describe("Testing jsonapi-client", function() {
       ], function(err) {
         assert.equal(err, null);
         done();
+      });
+    });
+
+    it("allows us to create and set relations before an initial sync", function(done) {
+      var someTag, newArticle;
+
+      client.find("tags", { }).then(function(allTags) {
+        someTag = allTags[0];
+      }).then(function() {
+        return client.create("articles")
+          .set("title", "some fancy booklet")
+          .set("content", "oh-la-la!")
+          .relationships("tags").add(someTag)
+          .sync();
+      }).then(function(newlyCreatedArticle) {
+        newArticle = newlyCreatedArticle;
+        return someTag.fetch("articles");
+      }).then(function() {
+        assert.equal(someTag.articles[0], newArticle);
+        done();
+      }).catch(function(err) {
+        setTimeout(function() { throw err; }, 0);
       });
     });
   });


### PR DESCRIPTION
This PR enables us to create a new resource, set attributes on it, AND set relationships on it, before sync'ing it with the remote api. Attempting to add a non-existant resource (one that doesn't exist in the remote service) to a relationship will now error. We make the assumption that the developer knows what they're doing and that the relationships they're assigning to really do exist.

Here's a snippet from a test:

``` javascript
return client.create("articles")
  .set("title", "some fancy booklet")
  .set("content", "oh-la-la!")
  .relationships("tags").add(someTag)
  .sync();
```

This addresses https://github.com/holidayextras/jsonapi-server/issues/105
