### PR TITLE
Allow options to be passed in to Client to set cacheDuration

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1,11 +1,13 @@
 /* @flow weak */
 "use strict";
-var Client = module.exports = function(path, auth) {
+var Client = module.exports = function(path, auth, options) {
   if (!path) {
     throw new Error("API path is needed to construct an instanceof jsonapi-client");
   }
   auth = auth || { };
-  this._construct(path, auth);
+  options = options || {};
+  
+  this._construct(path, auth, options);
 };
 
 if (typeof window !== "undefined") {
@@ -19,8 +21,8 @@ Client.Resource = Resource;
 var Transport = require("./Transport");
 var createResourceCache = require("./resourceCache");
 
-Client.prototype._construct = function(path, auth) {
-  this._resourceCache = createResourceCache();
+Client.prototype._construct = function(path, auth, options) {
+  this._resourceCache = createResourceCache(options);
   this._transport = new Transport(path, auth);
 };
 

--- a/lib/resourceCache.js
+++ b/lib/resourceCache.js
@@ -1,9 +1,11 @@
 /* @flow weak */
 "use strict";
-module.exports = function createResourceCache() {
+module.exports = function createResourceCache(options) {
+  options = options || { };
   var resourceCache = {};
 
-  resourceCache._cacheDuration = 5000;
+  resourceCache._cacheDuration = options.cacheDuration || 5000;
+
   if (typeof module === undefined) {
     resourceCache._cacheDuration = null;
   }

--- a/test/read.js
+++ b/test/read.js
@@ -293,4 +293,18 @@ describe("Testing jsonapi-client", function() {
     });
   });
 
+    describe("Initializes safely", function() {
+      it("accepts options as an optional parameter", function() {
+
+        var auth = {};
+        var options = {
+          cacheDuration: 500
+        };
+        var clientWithOptions = new Client("http://localhost:16006/rest", auth, options);
+        assert.notEqual(clientWithOptions, null);
+
+      });
+    });
+
+
 });


### PR DESCRIPTION
We are using the jsonapi-client within AWS Lambda functions. The 5000ms cacheDuration means the lambda is held open (and does not return) for at least 5000ms until the cache disposes. 

I've been running it with a 500ms cacheDuration in my functions.

I just opened a PR to see what you thought? I don't mind if you close it :-)