### PR TITLE
Fix error EUNKNOWN on 204 response

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -82,6 +82,10 @@ Transport.prototype._action = function(method, url, data, callback) {
       return callback(realErrors[0]);
     }
 
+    if (payload.statusCode == 204) {
+      return callback(null, payload.req, payload.req._data.data, payload.req._data.included);
+    }
+
     if (!payload.body) {
       try {
         payload.body = JSON.parse(payload.text);


### PR DESCRIPTION
All empty responses return a 500 EUNKNOWN error, the jsonapi spec however states that 204 responses are a valid response for POST, PATCH & DELETE requests where the result matches the request body. Here an excerpt from the spec:

> A server MUST return a 204 No Content status code if an update is successful and the representation of the resource in the request matches the result.
> - http://jsonapi.org/format/#crud-deleting