### PR TITLE
jsonapi-server package bump and attempt to fix CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - "4.2.6"
+  - 4
+  - 6
+  - 7
 script: "npm run $TEST_STEP"
 addons:
   firefox: "latest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,11 @@ node_js:
   - 4
   - 6
   - 7
-script: "npm run $TEST_STEP"
 addons:
   firefox: "latest"
-env:
-  matrix:
-    - TEST_STEP=jscpd
-    - TEST_STEP=lint
-    - TEST_STEP=test
-    - TEST_STEP=flow
-notifications:
-  email: false
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+script: npm run ci
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A javascript module designed to make it really easy to consume a `json:api` serv
 $ npm install --save jsonapi-client@holidayextras/jsonapi-client
 ```
 
+note: this project requires a Node.js version of at least `4.5.0`.
+
 ### Motivation / Justification / Rationale
 
 Consuming a json:api service from within Javascript is a non-trivial affair. Setting up a transport mechanism, authentication, making requests to standardised HTTP routes, error handling, pagination and expanding an inclusion tree... All of these things represent barriers to consuming an API. This module takes away all the hassle and lets developers focus on interacting with a rich API without wasting developer time focusing on anything other than shipping valuable features.

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "complexity": "./node_modules/plato/bin/plato -r -d complexity lib",
     "lint": "./node_modules/.bin/eslint ./lib/* ./test/*.js --quiet && echo '✔ All good!'",
     "flow": "node ./node_modules/flow-bin/cli.js && echo '✔ All good!'",
-    "jscpd": "jscpd --blame -p ./lib/ || echo 'Finished!'"
+    "jscpd": "jscpd --blame -p ./lib/ || echo 'Finished!'",
+    "ci": "npm run lint && npm run flow && npm run jscpd && npm run test"
   },
   "config": {
     "blanket": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "flow-bin": "^0.28.0",
     "jscpd": "^0.6.1",
     "eslint-config-eslint": "3.0.0",
-    "jsonapi-server": "1.15.4",
+    "jsonapi-server": "3.0.0",
     "karma": "1.1.0",
     "karma-chrome-launcher": "1.0.1",
     "karma-firefox-launcher": "1.0.0",
@@ -42,6 +42,9 @@
     "phantomjs": "2.1.7",
     "plato": "1.5.0",
     "uglifyjs": "2.4.10"
+  },
+  "engines": {
+    "node": ">=4.5"
   },
   "scripts": {
     "build": "mkdir -p dist && ./node_modules/.bin/browserify lib/Client.js | ./node_modules/.bin/uglifyjs -cm -o dist/jsonapi-client.min.js 2> /dev/null && echo '✔ Assets built!'",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "flow-bin": "^0.28.0",
     "jscpd": "^0.6.1",
     "eslint-config-eslint": "3.0.0",
-    "jsonapi-server": "3.0.0",
+    "jsonapi-server": "3.0.1",
     "karma": "1.1.0",
     "karma-chrome-launcher": "1.0.1",
     "karma-firefox-launcher": "1.0.0",

--- a/test/read.js
+++ b/test/read.js
@@ -155,6 +155,10 @@ describe("Testing jsonapi-client", function() {
             "id": "d850ea75-4427-4f81-8595-039990aeede5",
             "type": "people"
           },
+          "tags": [
+            "galapagos",
+            "emperor"
+          ],
           "articles": undefined
         });
 
@@ -265,6 +269,10 @@ describe("Testing jsonapi-client", function() {
             "id": "d850ea75-4427-4f81-8595-039990aeede5",
             "type": "people"
           },
+          "tags": [
+            "galapagos",
+            "emperor"
+          ],
           "articles": undefined
         });
 


### PR DESCRIPTION
Maintenance updates for this repo.

-> Updated .travis.yml to include a number of node versions (4, 6, 7).
-> Added a note to the repo README to state the required version of node.js to be >=4.5.0.
-> Updated the jsonapi-server version dependency from 1.15.4 -> 3.0.0.
-> Added required minimum node.js engine field to package.json.
-> Updated the tests to reflect additional data coming back in fetches related to foreign resources (tags element in jsonapi-server 3.0.0)